### PR TITLE
Update search_params.go

### DIFF
--- a/server/public/model/search_params.go
+++ b/server/public/model/search_params.go
@@ -11,7 +11,7 @@ import (
 )
 
 var searchTermPuncStart = regexp.MustCompile(`^[^\pL\d\s#"]+`)
-var searchTermPuncEnd = regexp.MustCompile(`[^\pL\d\s*"]+$`)
+var searchTermPuncEnd = regexp.MustCompile(`[^\pL\p{Thai}\d\s*"]+$`)
 
 type SearchParams struct {
 	Terms                  string   `json:"terms,omitempty"`


### PR DESCRIPTION
Otherwise some Thai vowels and tonemarks at the end of the search term will be removed.

E.g., สวัสดี will become only สวัสด, which is wrong.

This fix allows all Thai characters to be at the end of the search term.
