### PR TITLE
FIx Thai tone marks and vowels at the end of the search term wrongly removed

### DIFF
--- a/server/public/model/search_params.go
+++ b/server/public/model/search_params.go
@@ -11,7 +11,7 @@ import (
 )
 
 var searchTermPuncStart = regexp.MustCompile(`^[^\pL\d\s#"]+`)
-var searchTermPuncEnd = regexp.MustCompile(`[^\pL\p{Thai}\d\s*"]+$`)
+var searchTermPuncEnd = regexp.MustCompile(`[^\pL\p{M}\d\s*"]+$`)
 
 type SearchParams struct {
 	Terms                  string   `json:"terms,omitempty"`

--- a/server/public/model/search_params_test.go
+++ b/server/public/model/search_params_test.go
@@ -1012,11 +1012,44 @@ func TestParseSearchFlags2(t *testing.T) {
 			},
 		},
 		{
-			Name:  "string thai",
+			Name:  "string end with  thai upper vowel",
 			Input: "สวัสดี",
 			Words: []searchWord{
 				{
 					value:   "สวัสดี",
+					exclude: false,
+				},
+			},
+			Flags: []flag{},
+		},
+		{
+			Name:  "string end with  thai upper tone mark",
+			Input: "ที่นี่",
+			Words: []searchWord{
+				{
+					value:   "ที่นี่",
+					exclude: false,
+				},
+			},
+			Flags: []flag{},
+		},
+		{
+			Name:  "string end with  thai upper indication mark",
+			Input: "การันต์",
+			Words: []searchWord{
+				{
+					value:   "การันต์",
+					exclude: false,
+				},
+			},
+			Flags: []flag{},
+		},
+		{
+			Name:  "string end with  thai lower vowel",
+			Input: "กตัญญู",
+			Words: []searchWord{
+				{
+					value:   "กตัญญู",
 					exclude: false,
 				},
 			},

--- a/server/public/model/search_params_test.go
+++ b/server/public/model/search_params_test.go
@@ -1011,6 +1011,17 @@ func TestParseSearchFlags2(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:  "string thai",
+			Input: "สวัสดี",
+			Words: []searchWord{
+				{
+					value:   "สวัสดี",
+					exclude: false,
+				},
+			},
+			Flags: []flag{},
+		},
 	} {
 		t.Run(testCase.Name, func(t *testing.T) {
 			words, flags := parseSearchFlags(splitWords(testCase.Input))


### PR DESCRIPTION
Thai vowels and tone marks at the end of the search term are now (likely unintentionally) removed.

E.g., สวัสดี will become only สวัสด, which is wrong. The correct output should be สวัสดี (exactly the same as the search term).

This fix allows all Thai characters to be at the end of the search term.